### PR TITLE
fix: add Anthropic provider + fix model not cleared on unload

### DIFF
--- a/src/providers/claude.ts
+++ b/src/providers/claude.ts
@@ -1,0 +1,54 @@
+import type { Provider } from './index.js';
+
+export const claudeProvider: Provider = {
+  id: 'claude',
+  name: 'Anthropic (Claude)',
+  description: 'Official Anthropic Claude API',
+  regions: [
+    {
+      id: 'global',
+      name: 'Global',
+      baseUrl: 'https://api.anthropic.com',
+      apiKeyUrl: 'https://console.anthropic.com/settings/keys',
+    },
+  ],
+  models: [
+    {
+      id: 'claude-opus-4-5-20251120',
+      name: 'Claude Opus 4.5',
+      default: true,
+    },
+    {
+      id: 'claude-sonnet-4-20250514',
+      name: 'Claude Sonnet 4',
+    },
+    {
+      id: 'claude-haiku-3-5-20250620',
+      name: 'Claude Haiku 3.5',
+    },
+    {
+      id: 'claude-3-5-sonnet-20241022',
+      name: 'Claude 3.5 Sonnet',
+    },
+    {
+      id: 'claude-3-opus-20240229',
+      name: 'Claude 3 Opus',
+    },
+    {
+      id: 'claude-3-sonnet-20240229',
+      name: 'Claude 3 Sonnet',
+    },
+    {
+      id: 'claude-3-haiku-20240307',
+      name: 'Claude 3 Haiku',
+    },
+  ],
+  getEnvOverrides(model: string): Record<string, string> {
+    return {
+      ANTHROPIC_MODEL: model,
+    };
+  },
+  getValidateUrl(_regionId: string): string {
+    return 'https://api.anthropic.com/v1/models';
+  },
+};

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -27,8 +27,9 @@ export interface Provider {
 import { zhipuProvider } from './zhipu.js';
 import { minimaxProvider } from './minimax.js';
 import { kimiProvider } from './kimi.js';
+import { claudeProvider } from './claude.js';
 
-const providers: Provider[] = [zhipuProvider, minimaxProvider, kimiProvider];
+const providers: Provider[] = [claudeProvider, zhipuProvider, minimaxProvider, kimiProvider];
 
 export function getProvider(id: string): Provider | undefined {
   return providers.find(p => p.id === id);


### PR DESCRIPTION
**Problem:** After switching to a third-party provider, `ccs unload` removed env vars but left the `model` property in `settings.json`, preventing a clean switch back to Anthropic.

**Changes:**
- Add official Anthropic (Claude) provider (`claude.ts`) – enables switching back to Anthropic within Claude Code
- Fix `unloadProviderConfig` to also remove `model` from settings (previously only env vars were cleaned up)
- Fix `loadProviderConfig` to correctly set the `model` property in `settings.json`
- Add `mapModelToSetting` helper to map provider model IDs to Claude Code shorthands (opus/sonnet/haiku)

**Tested:** Switching between Kimi → Anthropic and back works correctly after these fixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Anthropic Claude API provider integration with support for Opus, Sonnet, and Haiku models
  * Implemented automatic configuration handling for Claude provider selection and model preferences

<!-- end of auto-generated comment: release notes by coderabbit.ai -->